### PR TITLE
code thrust particle size directly to avoid expensive slice

### DIFF
--- a/src/ThrustSystem.js
+++ b/src/ThrustSystem.js
@@ -78,6 +78,7 @@ class ThrustSystem
             ctx.translate(dx*zoomScale, dy*zoomScale);
         }
         if (theta) ctx.rotate(theta*DEGREES_TO_RAD);
+        this.particles.forEach(particle=>particle.render())
     }
 }
 

--- a/src/ThrustSystem.js
+++ b/src/ThrustSystem.js
@@ -6,33 +6,42 @@ colorList = ["#C32005AA", "#C43006AA","#D63E06AA", "#ED6414AA",
     "#FBF787AA", "#FCFBC2AA", "#F4FBD0AA", "#FFFFFFAA",
     "#CCAAFFAA", "#DDBBFFAA", "#CCDDFFAA", "#CCDDFFAA"];
 
+class ParticleShape
+{
+   constructor(pixelSize, height, baseAge)
+   {
+       this.pixelSize = pixelSize
+       this.height = height
+       this.baseAge = baseAge
+   }
+}
 
 class Particle
 {
-    constructor(pixelSize) {
-        this.pixelSize = pixelSize
+    constructor(shape) {
+        this.shape = shape
     }
 
-    respawn(height,baseAge)
+    respawn()
     {
+        let height = this.shape.height
         this.x = 0;
-        this.y = (Math.random() * height) - height / 2;
-        let minV = -(1 + 10 * 0 + 2 * (0));
-        let maxV = -(1 + 10 * (1) + 2 * (height / 2 - 0));
-        this.vx = -(1 + 10 * Math.random() + 2 * (height / 2 - Math.abs(this.y)));
-        this.age = Math.floor(baseAge / 2 + baseAge * Math.random());
-        this.color = colorList[Math.floor(colorList.length * (this.vx - minV) / (maxV - minV))];
+        this.y = (Math.random()*height)-height/2;
+        let minV = -(1 + 10*0 + 2*(0));
+        let maxV = -(1 + 10*(1) + 2*(height/2-0));
+        this.vx = -(1 + 10*Math.random() + 2*(height/2-Math.abs(this.y)));
+        this.age = Math.floor(this.shape.baseAge*(Math.random() + 0.5));
+        this.color = colorList[Math.floor(colorList.length*(this.vx-minV)/(maxV-minV))];
     }
 
-    render(height, baseAge)
+    render( )
     {
         this.x += this.vx;
         this.age--;
         ctx.fillStyle = this.color;
-        if (brighter) ctx.fillRect(this.x, this.y - 1, 3, 3);
-        else ctx.fillRect(this.x, this.y, 1, 1);
-        if (this.age <= 0) this.respawn(height, baseAge);
-    }
+        ctx.fillRect(this.x, this.y-1, this.shape.pixelSize, this.shape.pixelSize)
+        if (this.age <= 0) this.respawn();
+   }
 }
 
 class ThrustSystem
@@ -40,11 +49,12 @@ class ThrustSystem
     constructor(particleCount, height, baseAge)
     {
         let n = Math.floor(particleCount/2);
-        this.height = height;
-        this.baseAge = baseAge;
-        this.particles = (new Array(n).fill(new Particle(3)))
-                  .concat(new Array(n).fill(new Particle(1)))
-        this.particles.forEach(particle=>particle.respawn(this.height, this.baseAge))
+        // separate object to share and save space
+        let brightShape = new ParticleShape(3, height, baseAge)
+        let dimShape = new ParticleShape(1, height, baseAge)
+        this.particles = (new Array(n).fill(new Particle(brightShape)))
+                  .concat(new Array(n).fill(new Particle(dimShape)))
+        this.particles.forEach(particle=>particle.respawn())
     }
 
 
@@ -68,7 +78,7 @@ class ThrustSystem
             ctx.translate(dx*zoomScale, dy*zoomScale);
         }
         if (theta) ctx.rotate(theta*DEGREES_TO_RAD);
-        this.particles.forEach(particle=>particle.render(this.height,this.baseAge))
+        this.particles.forEach(particle=>particle.render())
     }
 }
 

--- a/src/ThrustSystem.js
+++ b/src/ThrustSystem.js
@@ -9,6 +9,10 @@ colorList = ["#C32005AA", "#C43006AA","#D63E06AA", "#ED6414AA",
 
 class Particle
 {
+    constructor(pixelSize) {
+        this.pixelSize = pixelSize
+    }
+
     respawn(height,baseAge)
     {
         this.x = 0;
@@ -20,13 +24,12 @@ class Particle
         this.color = colorList[Math.floor(colorList.length*(this.vx-minV)/(maxV-minV))];
     }
 
-    render(brighter, height, baseAge)
+    render(height, baseAge)
     {
          this.x += this.vx;
          this.age--;
          ctx.fillStyle = this.color;
-         if (brighter) ctx.fillRect(this.x, this.y-1, 3, 3);
-         else ctx.fillRect(this.x, this.y, 1, 1);
+         ctx.fillRect(this.x, this.y-1, this.pixelSize, this.pixelSize)
          if (this.age <= 0) this.respawn(height, baseAge);
    }
 }
@@ -35,11 +38,11 @@ class ThrustSystem
 {
     constructor(particleCount, height, baseAge)
     {
-        let n = particleCount;
+        let n = Math.floor(particleCount/2);
         this.height = height;
         this.baseAge = baseAge;
-        this.particles = new Array(n)
-        this.particles.fill(new Particle())
+        this.particles = (new Array(n).fill(new Particle(3)))
+                  .concat(new Array(n).fill(new Particle(1)))
         this.particles.forEach(particle=>particle.respawn(this.height, this.baseAge))
     }
 
@@ -55,10 +58,7 @@ class ThrustSystem
         ctx.rotate(ship.heading*DEGREES_TO_RAD);
         ctx.translate(dx*zoomScale, dy*zoomScale);
         if (theta) ctx.rotate(theta*DEGREES_TO_RAD);
-
-        let m = Math.floor(0.5*this.particles.length);
-        this.particles.slice(0,m).forEach(particle=>particle.render(true,this.height,this.baseAge))
-        this.particles.slice(m).forEach(particle=>particle.render(false,this.height,this.baseAge))
+        this.particles.forEach(particle=>particle.render(this.height,this.baseAge))
     }
 }
 

--- a/src/ThrustSystem.js
+++ b/src/ThrustSystem.js
@@ -9,7 +9,11 @@ colorList = ["#C32005AA", "#C43006AA","#D63E06AA", "#ED6414AA",
 
 class Particle
 {
-    respawn(height, baseAge)
+    constructor(pixelSize) {
+        this.pixelSize = pixelSize
+    }
+
+    respawn(height,baseAge)
     {
         this.x = 0;
         this.y = (Math.random() * height) - height / 2;
@@ -20,7 +24,7 @@ class Particle
         this.color = colorList[Math.floor(colorList.length * (this.vx - minV) / (maxV - minV))];
     }
 
-    render(brighter, height, baseAge)
+    render(height, baseAge)
     {
         this.x += this.vx;
         this.age--;
@@ -35,11 +39,11 @@ class ThrustSystem
 {
     constructor(particleCount, height, baseAge)
     {
-        let n = particleCount;
+        let n = Math.floor(particleCount/2);
         this.height = height;
         this.baseAge = baseAge;
-        this.particles = new Array(n)
-        this.particles.fill(new Particle())
+        this.particles = (new Array(n).fill(new Particle(3)))
+                  .concat(new Array(n).fill(new Particle(1)))
         this.particles.forEach(particle=>particle.respawn(this.height, this.baseAge))
     }
 
@@ -64,10 +68,7 @@ class ThrustSystem
             ctx.translate(dx*zoomScale, dy*zoomScale);
         }
         if (theta) ctx.rotate(theta*DEGREES_TO_RAD);
-
-        let m = Math.floor(0.5*this.particles.length);
-        this.particles.slice(0,m).forEach(particle=>particle.render(true,this.height,this.baseAge))
-        this.particles.slice(m).forEach(particle=>particle.render(false,this.height,this.baseAge))
+        this.particles.forEach(particle=>particle.render(this.height,this.baseAge))
     }
 }
 


### PR DESCRIPTION
Avoid expensive slice in thrust particular calculation.  This does use more storage in Particle.  We could move age and height into Particle class as well for cleaner code, but wasting more storage.  Alternatively, thrust particles could be split into two lists so save the pixelSize field.